### PR TITLE
Meal plan item notes placeholder must be deleted by user

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -12,6 +12,12 @@
     text-indent: 10px;
     /* margin-bottom: 0.5rem; */
 }
+/* placeholder code for item note */
+[contentEditable=true]:empty:before {
+    content: attr(placeholder);
+    opacity: 0.6;
+}
+
 .save-button {
     display: none;
     border: none;

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -97,7 +97,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="monday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" placeholder="e.g. Use more cinnamon!" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -140,7 +140,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -148,7 +148,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -168,7 +168,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -176,7 +176,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -196,7 +196,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -204,7 +204,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -223,7 +223,7 @@
                           <button><span class="far fa-edit"></span></button>
                           <button><span class="far fa-sticky-note"></span></button>
                           <span class='fa fa-trash meal-plan-trash'></span><br />
-                          <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                          <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                           <button class="save-button button1" type="button">save</button>
 
                         <% }else { %>
@@ -231,7 +231,7 @@
                           <button><span class="far fa-edit"></span></button>
                           <button><span class="far fa-sticky-note"></span></button>
                           <span class='fa fa-trash meal-plan-trash'></span><br />
-                          <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                          <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                           <button class="save-button button1" type="button">save</button>
                         <% } %>
                       </li>
@@ -269,7 +269,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="tuesday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -284,7 +284,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -292,7 +292,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -312,7 +312,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -320,7 +320,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -340,7 +340,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -348,7 +348,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -368,7 +368,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -376,7 +376,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -413,7 +413,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="wednesday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -428,7 +428,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -436,7 +436,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -456,7 +456,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -464,7 +464,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -484,7 +484,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -492,7 +492,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -511,7 +511,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -519,7 +519,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -557,7 +557,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="thursday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -572,7 +572,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -580,7 +580,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -600,7 +600,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -608,7 +608,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -628,7 +628,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -636,7 +636,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -656,7 +656,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -664,7 +664,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -703,7 +703,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="friday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -718,7 +718,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -726,7 +726,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -746,7 +746,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -754,7 +754,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -774,7 +774,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -782,7 +782,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -802,7 +802,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -810,7 +810,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -849,7 +849,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="saturday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -864,7 +864,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -872,7 +872,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -892,7 +892,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -900,7 +900,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -920,7 +920,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -928,7 +928,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -948,7 +948,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -956,7 +956,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -995,7 +995,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="sunday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -1010,7 +1010,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -1018,7 +1018,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -1038,7 +1038,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -1046,7 +1046,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -1066,7 +1066,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -1074,7 +1074,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
@@ -1094,7 +1094,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -1102,7 +1102,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -97,7 +97,7 @@
                   </select>
                   <input type="hidden" name="weekday" value="monday" />
                   <input type="hidden" name="complete" value="false" />
-                  <input type="hidden" name="note" value="note about item" />
+                  <input type="hidden" name="note" placeholder="e.g. Use more cinnamon!" />
                   <button type="submit">Add</button>
                 </form>
 
@@ -112,7 +112,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
@@ -120,7 +120,7 @@
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
                             <span class='fa fa-trash meal-plan-trash'></span><br />
-                            <div class="item-note" contenteditable="true"><%= mealPlanStuff[i].note %></div>
+                            <div class="item-note" contenteditable="true" placeholder="Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>


### PR DESCRIPTION
### Overview
This pull request addresses the issue of the meal plan item notes placeholder needing to be deleted by the user. It was, in fact, not a placeholder at all, but a preset value.

### Features Added
- Implements CSS workarounds to remove placeholders from contenteditable divs for meal plan items.
- Applies changes to ensure all days and meal times are affected by the placeholder adjustments.

### Implementation Details
- Develops a CSS workaround to apply the contenteditable placeholder behavior uniformly across all meal plan items. Divs do not come standard with a placeholder attribute. This pr effectively adds one.

### Testing
- Conducts manual tests to confirm that the diy placeholders function similarly to placeholder attributes (e.g. within an input element), and that users can edit meal plan item notes without issues.

### Future Work
- Address the alignment of the cursor when the user first clicks inside the content editable div

### Related Issues
- Fixes issue-#3 Meal Plan item notes placeholder must be deleted by user
- Issue-#4 Meal Plan item notes contenteditable div cursor position

### Commits in this PR
- bugfix: apply css contenteditable div placeholder workaround to all days and meal times
- bugfix: make a workaround via css for a placeholder attribute on contenteditable div (the note for each meal plan item). Just for Monday breakfast so far.