### PR TITLE
Grocery List Mark In/Complete Functionality for All Categories

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -79,6 +79,8 @@ async function markCompleteMealPlan(){
     const itemText = this.parentNode.childNodes[1].innerText
     console.log('itemText: ', itemText)
     let id = this.parentNode.id
+    
+    console.log(this.parentNode)
 
     id = id.charAt(0).toUpperCase() + id.slice(1)
     // console.log('id: ', id)
@@ -95,7 +97,7 @@ async function markCompleteMealPlan(){
           })
         const data = await response.json()
         console.log(data)
-        location.reload()
+        // location.reload()
     }catch(err){
         console.log(err)
     }
@@ -323,6 +325,7 @@ async function subNumOfItem(){
 async function markCompleteGroceryList(){
     const itemText = this.parentNode.childNodes[1].innerText
     console.log('itemText: ', itemText)
+    console.log(this.parentNode)
     let id = this.parentNode.id
 
     id = id.charAt(0).toUpperCase() + id.slice(1)

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -338,7 +338,7 @@ async function markCompleteGroceryList(){
 
     try{
         // const response = await fetch(`markCompleteGroceryList${id}`, {
-        const response = await fetch(`markCompleteGroceryListProduce`, {
+        const response = await fetch(`markCompleteGroceryList`, {
             method: 'put',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
@@ -369,7 +369,7 @@ async function markIncompleteGroceryList(){
 
     try{
         // const response = await fetch(`markCompleteGroceryList${id}`, {
-        const response = await fetch(`markIncompleteGroceryListProduce`, {
+        const response = await fetch(`markIncompleteGroceryList`, {
             method: 'put',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -353,30 +353,36 @@ async function markCompleteGroceryList(){
     }
 }
 
-// async function markIncompleteMealPlan(){
-//     const itemText = this.parentNode.childNodes[1].innerText
-//     let id = this.parentNode.id
+async function markIncompleteGroceryList(){
+    // const itemText = this.parentNode.childNodes[1].innerText
+    // console.log('itemText: ', itemText)
+    console.log(this.parentNode)
+    let id = this.parentNode.id
 
-//     id = id.charAt(0).toUpperCase() + id.slice(1)
-//     // console.log('id: ', id)
 
-//     console.log('markIncomplete this.parentNode.id: ', this.parentNode.id)
+    // {"_id":{"$oid":"672ab5de80a94eeea4d2834a"},"itemNameProduce":"bananas","category":"produce","numItem":"1","complete":"false"}
 
-//     try{
-//         const response = await fetch(`markIncompleteMealPlan${id}`, {
-//             method: 'put',
-//             headers: {'Content-Type': 'application/json'},
-//             body: JSON.stringify({
-//                 'itemFromJS': itemText
-//             })
-//           })
-//         const data = await response.json()
-//         console.log(data)
-//         location.reload()
-//     }catch(err){
-//         console.log(err)
-//     }
-// }
+    // id = id.charAt(0).toUpperCase() + id.slice(1)
+    console.log('id: ', id)
+
+    console.log('markIncomplete this.parentNode.id: ', this.parentNode.id)
+
+    try{
+        // const response = await fetch(`markCompleteGroceryList${id}`, {
+        const response = await fetch(`markIncompleteGroceryListProduce`, {
+            method: 'put',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                'idFromJS': id
+            })
+          })
+        const data = await response.json()
+        console.log(data)
+        location.reload()
+    }catch(err){
+        console.log(err)
+    }
+}
 
 // this only works for Mondays
 // async function markCompleteGroceryList(){

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -323,30 +323,34 @@ async function subNumOfItem(){
 
 
 async function markCompleteGroceryList(){
-    const itemText = this.parentNode.childNodes[1].innerText
-    console.log('itemText: ', itemText)
+    // const itemText = this.parentNode.childNodes[1].innerText
+    // console.log('itemText: ', itemText)
     console.log(this.parentNode)
     let id = this.parentNode.id
 
-    id = id.charAt(0).toUpperCase() + id.slice(1)
+
+    // {"_id":{"$oid":"672ab5de80a94eeea4d2834a"},"itemNameProduce":"bananas","category":"produce","numItem":"1","complete":"false"}
+
+    // id = id.charAt(0).toUpperCase() + id.slice(1)
     console.log('id: ', id)
 
     console.log('markComplete this.parentNode.id: ', this.parentNode.id)
 
-    // try{
-    //     const response = await fetch(`markCompleteGroceryList${id}`, {
-    //         method: 'put',
-    //         headers: {'Content-Type': 'application/json'},
-    //         body: JSON.stringify({
-    //             'itemFromJS': itemText
-    //         })
-    //       })
-    //     const data = await response.json()
-    //     console.log(data)
-    //     location.reload()
-    // }catch(err){
-    //     console.log(err)
-    // }
+    try{
+        // const response = await fetch(`markCompleteGroceryList${id}`, {
+        const response = await fetch(`markCompleteGroceryListProduce`, {
+            method: 'put',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                'idFromJS': id
+            })
+          })
+        const data = await response.json()
+        console.log(data)
+        location.reload()
+    }catch(err){
+        console.log(err)
+    }
 }
 
 // async function markIncompleteMealPlan(){

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -319,52 +319,106 @@ async function subNumOfItem(){
     }
 }
 
+
 async function markCompleteGroceryList(){
-    // console.log('incomplete: ', Array.from(incompleteGroceryList))
-    // console.log('incomplete: ', Array.from(testComGroceryList))
-
     const itemText = this.parentNode.childNodes[1].innerText
-    // console.log('itemText:', itemText)
-    // console.log(this.parentNode.childNodes)
-    try{
-        const response = await fetch('markCompleteGroceryListProduce', {
-            method: 'put',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                'itemFromJS': itemText
-            })
-          })
-        const data = await response.json()
-        console.log(data)
-        location.reload()
+    console.log('itemText: ', itemText)
+    let id = this.parentNode.id
 
-    }catch(err){
-        console.log(err)
-    }
+    id = id.charAt(0).toUpperCase() + id.slice(1)
+    console.log('id: ', id)
+
+    console.log('markComplete this.parentNode.id: ', this.parentNode.id)
+
+    // try{
+    //     const response = await fetch(`markCompleteGroceryList${id}`, {
+    //         method: 'put',
+    //         headers: {'Content-Type': 'application/json'},
+    //         body: JSON.stringify({
+    //             'itemFromJS': itemText
+    //         })
+    //       })
+    //     const data = await response.json()
+    //     console.log(data)
+    //     location.reload()
+    // }catch(err){
+    //     console.log(err)
+    // }
 }
 
-async function markIncompleteGroceryList(){
-    // console.log('complete: ', Array.from(completeGroceryList))
-    // console.log('complete: ', Array.from(testIncGroceryList))
+// async function markIncompleteMealPlan(){
+//     const itemText = this.parentNode.childNodes[1].innerText
+//     let id = this.parentNode.id
 
-    const itemText = this.parentNode.childNodes[1].innerText
-    // console.log('itemText', itemText)
-    try{
-        const response = await fetch('markIncompleteGroceryListProduce', {
-            method: 'put',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                'itemFromJS': itemText
-            })
-          })
-        const data = await response.json()
-        console.log(data)
-        location.reload()
+//     id = id.charAt(0).toUpperCase() + id.slice(1)
+//     // console.log('id: ', id)
 
-    }catch(err){
-        console.log(err)
-    }
-}
+//     console.log('markIncomplete this.parentNode.id: ', this.parentNode.id)
+
+//     try{
+//         const response = await fetch(`markIncompleteMealPlan${id}`, {
+//             method: 'put',
+//             headers: {'Content-Type': 'application/json'},
+//             body: JSON.stringify({
+//                 'itemFromJS': itemText
+//             })
+//           })
+//         const data = await response.json()
+//         console.log(data)
+//         location.reload()
+//     }catch(err){
+//         console.log(err)
+//     }
+// }
+
+// this only works for Mondays
+// async function markCompleteGroceryList(){
+//     // console.log('incomplete: ', Array.from(incompleteGroceryList))
+//     // console.log('incomplete: ', Array.from(testComGroceryList))
+
+//     const itemText = this.parentNode.childNodes[1].innerText
+//     // console.log('itemText:', itemText)
+//     // console.log(this.parentNode.childNodes)
+//     try{
+//         const response = await fetch('markCompleteGroceryListProduce', {
+//             method: 'put',
+//             headers: {'Content-Type': 'application/json'},
+//             body: JSON.stringify({
+//                 'itemFromJS': itemText
+//             })
+//           })
+//         const data = await response.json()
+//         console.log(data)
+//         location.reload()
+
+//     }catch(err){
+//         console.log(err)
+//     }
+// }
+
+// this only works for Mondays
+// async function markIncompleteGroceryList(){
+//     // console.log('complete: ', Array.from(completeGroceryList))
+//     // console.log('complete: ', Array.from(testIncGroceryList))
+
+//     const itemText = this.parentNode.childNodes[1].innerText
+//     // console.log('itemText', itemText)
+//     try{
+//         const response = await fetch('markIncompleteGroceryListProduce', {
+//             method: 'put',
+//             headers: {'Content-Type': 'application/json'},
+//             body: JSON.stringify({
+//                 'itemFromJS': itemText
+//             })
+//           })
+//         const data = await response.json()
+//         console.log(data)
+//         location.reload()
+
+//     }catch(err){
+//         console.log(err)
+//     }
+// }
 
 
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
 const MongoClient = require("mongodb").MongoClient;
+const ObjectId = require("mongodb").ObjectId
 require("dotenv").config({ path: "./config/.env" });
 
 app.set("view engine", "ejs");
@@ -558,9 +559,12 @@ MongoClient.connect(dbConnectionStr)
 
     //Mark item complete Produce
     app.put("/markCompleteGroceryListProduce", (request, response) => {
+
+      console.log(request.body.idFromJS)
+
       groceryListCollection
         .updateOne(
-          { itemNameProduce: request.body.itemFromJS },
+          { "_id": new ObjectId("672ab5de80a94eeea4d2834a") },
           { $set: { complete: true } }
         )
         .then((result) => {

--- a/server.js
+++ b/server.js
@@ -250,7 +250,7 @@ MongoClient.connect(dbConnectionStr)
         .updateOne(
           { saturdaymeal: request.body.itemFromJS },
           { $set: { complete: false } },
-          {
+          { 
             sort: { _id: -1 },
             upsert: false,
           }
@@ -556,7 +556,7 @@ MongoClient.connect(dbConnectionStr)
         .catch((error) => console.error(error));
     });
 
-    //Mark item complete
+    //Mark item complete Produce
     app.put("/markCompleteGroceryListProduce", (request, response) => {
       groceryListCollection
         .updateOne(
@@ -570,11 +570,131 @@ MongoClient.connect(dbConnectionStr)
         .catch((error) => console.error(error));
     });
 
-    //Mark item incomplete
+    //Mark item incomplete Produce
     app.put("/markIncompleteGroceryListProduce", (request, response) => {
       groceryListCollection
         .updateOne(
           { itemNameProduce: request.body.itemFromJS },
+          { $set: { complete: false } }
+        )
+        .then((result) => {
+          console.log("Marked Incomplete");
+          response.json("Marked Incomplete");
+        })
+        .catch((error) => console.error(error));
+    });
+
+
+
+       //Mark item complete Proteins
+       app.put("/markCompleteGroceryListProteins", (request, response) => {
+        groceryListCollection
+          .updateOne(
+            { itemNameProteins: request.body.itemFromJS },
+            { $set: { complete: true } }
+          )
+          .then((result) => {
+            console.log("Marked Complete");
+            response.json("Marked Complete");
+          })
+          .catch((error) => console.error(error));
+      });
+  
+      //Mark item incomplete Proteins
+      app.put("/markIncompleteGroceryListProteins", (request, response) => {
+        groceryListCollection
+          .updateOne(
+            { itemNameProteins: request.body.itemFromJS },
+            { $set: { complete: false } }
+          )
+          .then((result) => {
+            console.log("Marked Incomplete");
+            response.json("Marked Incomplete");
+          })
+          .catch((error) => console.error(error));
+      });
+
+
+
+         //Mark item complete Pantry
+    app.put("/markCompleteGroceryListPantry", (request, response) => {
+      groceryListCollection
+        .updateOne(
+          { itemNamePantry: request.body.itemFromJS },
+          { $set: { complete: true } }
+        )
+        .then((result) => {
+          console.log("Marked Complete");
+          response.json("Marked Complete");
+        })
+        .catch((error) => console.error(error));
+    });
+
+    //Mark item incomplete Pantry
+    app.put("/markIncompleteGroceryListPantry", (request, response) => {
+      groceryListCollection
+        .updateOne(
+          { itemNamePantry: request.body.itemFromJS },
+          { $set: { complete: false } }
+        )
+        .then((result) => {
+          console.log("Marked Incomplete");
+          response.json("Marked Incomplete");
+        })
+        .catch((error) => console.error(error));
+    });
+
+
+
+       //Mark item complete Condiments
+       app.put("/markCompleteGroceryListCondiments", (request, response) => {
+        groceryListCollection
+          .updateOne(
+            { itemNameCondiments: request.body.itemFromJS },
+            { $set: { complete: true } }
+          )
+          .then((result) => {
+            console.log("Marked Complete");
+            response.json("Marked Complete");
+          })
+          .catch((error) => console.error(error));
+      });
+  
+      //Mark item incomplete Condiments
+      app.put("/markIncompleteGroceryListCondiments", (request, response) => {
+        groceryListCollection
+          .updateOne(
+            { itemNameCondiments: request.body.itemFromJS },
+            { $set: { complete: false } }
+          )
+          .then((result) => {
+            console.log("Marked Incomplete");
+            response.json("Marked Incomplete");
+          })
+          .catch((error) => console.error(error));
+      });
+
+
+
+         //Mark item complete Other
+    app.put("/markCompleteGroceryListOther", (request, response) => {
+      groceryListCollection
+        .updateOne(
+          { itemNameOther: request.body.itemFromJS },
+          { $set: { complete: true } }
+        )
+        .then((result) => {
+          console.log("Marked Complete");
+          response.json("Marked Complete");
+        })
+        .catch((error) => console.error(error));
+    });
+
+    //Mark item incomplete Other
+    app.put("/markIncompleteGroceryListOther", (request, response) => {
+      groceryListCollection
+        .updateOne(
+          { itemNameOther: request.body.itemFromJS },
           { $set: { complete: false } }
         )
         .then((result) => {

--- a/server.js
+++ b/server.js
@@ -557,11 +557,14 @@ MongoClient.connect(dbConnectionStr)
         .catch((error) => console.error(error));
     });
 
-    //Mark item complete Produce
+
+
+
+
+    //Mark item complete
     app.put("/markCompleteGroceryList", (request, response) => {
 
-      console.log(request.body.idFromJS)
-      // "672ab5de80a94eeea4d2834a"
+      // console.log(request.body.idFromJS)
 
       groceryListCollection
         .updateOne(
@@ -575,10 +578,10 @@ MongoClient.connect(dbConnectionStr)
         .catch((error) => console.error(error));
     });
 
-    //Mark item incomplete Produce
+    //Mark item incomplete
     app.put("/markIncompleteGroceryList", (request, response) => {
 
-      console.log(request.body.idFromJS)
+      // console.log(request.body.idFromJS)
 
       groceryListCollection
         .updateOne(
@@ -594,123 +597,7 @@ MongoClient.connect(dbConnectionStr)
 
 
 
-       //Mark item complete Proteins
-       app.put("/markCompleteGroceryListProteins", (request, response) => {
-        groceryListCollection
-          .updateOne(
-            { itemNameProteins: request.body.itemFromJS },
-            { $set: { complete: true } }
-          )
-          .then((result) => {
-            console.log("Marked Complete");
-            response.json("Marked Complete");
-          })
-          .catch((error) => console.error(error));
-      });
-  
-      //Mark item incomplete Proteins
-      app.put("/markIncompleteGroceryListProteins", (request, response) => {
-        groceryListCollection
-          .updateOne(
-            { itemNameProteins: request.body.itemFromJS },
-            { $set: { complete: false } }
-          )
-          .then((result) => {
-            console.log("Marked Incomplete");
-            response.json("Marked Incomplete");
-          })
-          .catch((error) => console.error(error));
-      });
 
-
-
-         //Mark item complete Pantry
-    app.put("/markCompleteGroceryListPantry", (request, response) => {
-      groceryListCollection
-        .updateOne(
-          { itemNamePantry: request.body.itemFromJS },
-          { $set: { complete: true } }
-        )
-        .then((result) => {
-          console.log("Marked Complete");
-          response.json("Marked Complete");
-        })
-        .catch((error) => console.error(error));
-    });
-
-    //Mark item incomplete Pantry
-    app.put("/markIncompleteGroceryListPantry", (request, response) => {
-      groceryListCollection
-        .updateOne(
-          { itemNamePantry: request.body.itemFromJS },
-          { $set: { complete: false } }
-        )
-        .then((result) => {
-          console.log("Marked Incomplete");
-          response.json("Marked Incomplete");
-        })
-        .catch((error) => console.error(error));
-    });
-
-
-
-       //Mark item complete Condiments
-       app.put("/markCompleteGroceryListCondiments", (request, response) => {
-        groceryListCollection
-          .updateOne(
-            { itemNameCondiments: request.body.itemFromJS },
-            { $set: { complete: true } }
-          )
-          .then((result) => {
-            console.log("Marked Complete");
-            response.json("Marked Complete");
-          })
-          .catch((error) => console.error(error));
-      });
-  
-      //Mark item incomplete Condiments
-      app.put("/markIncompleteGroceryListCondiments", (request, response) => {
-        groceryListCollection
-          .updateOne(
-            { itemNameCondiments: request.body.itemFromJS },
-            { $set: { complete: false } }
-          )
-          .then((result) => {
-            console.log("Marked Incomplete");
-            response.json("Marked Incomplete");
-          })
-          .catch((error) => console.error(error));
-      });
-
-
-
-         //Mark item complete Other
-    app.put("/markCompleteGroceryListOther", (request, response) => {
-      groceryListCollection
-        .updateOne(
-          { itemNameOther: request.body.itemFromJS },
-          { $set: { complete: true } }
-        )
-        .then((result) => {
-          console.log("Marked Complete");
-          response.json("Marked Complete");
-        })
-        .catch((error) => console.error(error));
-    });
-
-    //Mark item incomplete Other
-    app.put("/markIncompleteGroceryListOther", (request, response) => {
-      groceryListCollection
-        .updateOne(
-          { itemNameOther: request.body.itemFromJS },
-          { $set: { complete: false } }
-        )
-        .then((result) => {
-          console.log("Marked Incomplete");
-          response.json("Marked Incomplete");
-        })
-        .catch((error) => console.error(error));
-    });
 
     // Delete item
     app.delete("/deleteItemGroceryList", (request, response) => {

--- a/server.js
+++ b/server.js
@@ -561,10 +561,11 @@ MongoClient.connect(dbConnectionStr)
     app.put("/markCompleteGroceryListProduce", (request, response) => {
 
       console.log(request.body.idFromJS)
+      // "672ab5de80a94eeea4d2834a"
 
       groceryListCollection
         .updateOne(
-          { "_id": new ObjectId("672ab5de80a94eeea4d2834a") },
+          { _id: new ObjectId(request.body.idFromJS) },
           { $set: { complete: true } }
         )
         .then((result) => {
@@ -581,7 +582,7 @@ MongoClient.connect(dbConnectionStr)
 
       groceryListCollection
         .updateOne(
-          { "_id": new ObjectId("672ab5de80a94eeea4d2834a") },
+          { _id: new ObjectId(request.body.idFromJS) },
           { $set: { complete: false } }
         )
         .then((result) => {

--- a/server.js
+++ b/server.js
@@ -558,7 +558,7 @@ MongoClient.connect(dbConnectionStr)
     });
 
     //Mark item complete Produce
-    app.put("/markCompleteGroceryListProduce", (request, response) => {
+    app.put("/markCompleteGroceryList", (request, response) => {
 
       console.log(request.body.idFromJS)
       // "672ab5de80a94eeea4d2834a"
@@ -576,7 +576,7 @@ MongoClient.connect(dbConnectionStr)
     });
 
     //Mark item incomplete Produce
-    app.put("/markIncompleteGroceryListProduce", (request, response) => {
+    app.put("/markIncompleteGroceryList", (request, response) => {
 
       console.log(request.body.idFromJS)
 

--- a/server.js
+++ b/server.js
@@ -576,9 +576,12 @@ MongoClient.connect(dbConnectionStr)
 
     //Mark item incomplete Produce
     app.put("/markIncompleteGroceryListProduce", (request, response) => {
+
+      console.log(request.body.idFromJS)
+
       groceryListCollection
         .updateOne(
-          { itemNameProduce: request.body.itemFromJS },
+          { "_id": new ObjectId("672ab5de80a94eeea4d2834a") },
           { $set: { complete: false } }
         )
         .then((result) => {

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -149,7 +149,7 @@
                       <% for(let i = 0; i < groceryListItems.length; i++) { %>
 
                         <% if(groceryListItems[i].category === 'proteins') { %>
-                          <li class="item">
+                          <li id="<%= groceryListItems[i]._id %>" class="item">
 
                             <% if(groceryListItems[i].complete === true) { %>
                               <span class="item-name complete"><%= groceryListItems[i].itemNameProteins %></span>
@@ -203,7 +203,7 @@
                       <% for(let i = 0; i < groceryListItems.length; i++) { %>
 
                         <% if(groceryListItems[i].category === 'pantry') { %>
-                          <li class="item">
+                          <li id="<%= groceryListItems[i]._id %>" class="item">
 
                             <% if(groceryListItems[i].complete === true) { %>
                               <span class="item-name complete"><%= groceryListItems[i].itemNamePantry %></span>
@@ -257,7 +257,7 @@
                       <% for(let i = 0; i < groceryListItems.length; i++) { %>
 
                         <% if(groceryListItems[i].category === 'condiments') { %>
-                          <li class="item">
+                          <li id="<%= groceryListItems[i]._id %>" class="item">
 
                             <% if(groceryListItems[i].complete === true) { %>
                               <span class="item-name complete"><%= groceryListItems[i].itemNameCondiments %></span>
@@ -311,7 +311,7 @@
                       <% for(let i = 0; i < groceryListItems.length; i++) { %>
 
                         <% if(groceryListItems[i].category === 'other') { %>
-                          <li class="item">
+                          <li id="<%= groceryListItems[i]._id %>" class="item">
 
                             <% if(groceryListItems[i].complete === true) { %>
                               <span class="item-name complete"><%= groceryListItems[i].itemNameOther %></span>

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -95,7 +95,7 @@
                       <% for(let i = 0; i < groceryListItems.length; i++) { %>
 
                         <% if(groceryListItems[i].category === 'produce') { %>
-                          <li class="item">
+                          <li id="<%= groceryListItems[i]._id %>" class="item">
 
                             <% if(groceryListItems[i].complete === true) { %>
                               <span class="item-name complete"><%= groceryListItems[i].itemNameProduce %></span>
@@ -155,7 +155,7 @@
                               <span class="item-name complete"><%= groceryListItems[i].itemNameProteins %></span>
 
                             <% } else { %>
-                              <span class="item-name"><%= groceryListItems[i].itemNameProteins %></span>
+                              <span class="item-name incomplete"><%= groceryListItems[i].itemNameProteins %></span>
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
@@ -209,7 +209,7 @@
                               <span class="item-name complete"><%= groceryListItems[i].itemNamePantry %></span>
 
                             <% } else { %>
-                              <span class="item-name"><%= groceryListItems[i].itemNamePantry %></span>
+                              <span class="item-name incomplete"><%= groceryListItems[i].itemNamePantry %></span>
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
@@ -263,7 +263,7 @@
                               <span class="item-name complete"><%= groceryListItems[i].itemNameCondiments %></span>
 
                             <% } else { %>
-                              <span class="item-name"><%= groceryListItems[i].itemNameCondiments %></span>
+                              <span class="item-name incomplete"><%= groceryListItems[i].itemNameCondiments %></span>
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
@@ -317,7 +317,7 @@
                               <span class="item-name complete"><%= groceryListItems[i].itemNameOther %></span>
 
                             <% } else { %>
-                              <span class="item-name"><%= groceryListItems[i].itemNameOther %></span>
+                              <span class="item-name incomplete"><%= groceryListItems[i].itemNameOther %></span>
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>


### PR DESCRIPTION
### Overview  
This pull request addresses an issue where the "mark complete" and “mark incomplete” functionality on the grocery list page only works for the Produce section. This PR ensures the functionality works correctly for all categories and grocery list items, including those with duplicates, by targeting items using their unique `_id` which MongoDB assigns when a new document is created.

### Features Added  
- Dynamically targets "mark complete" and "mark incomplete" actions using the grocery list item's `_id`.
- Adds an "incomplete" class to grocery list items for better discernibility of item state in EJS code.
- Displays MongoDB `_id` in the `id` attribute of each grocery list item (`<li>`) for more accurate targeting.
- Implements server-side logic to handle marking items as complete/incomplete across all grocery list categories.

### Implementation Details  
- Refactor the logic for marking items as complete by utilizing the item's unique `_id`. This change allows the functionality to dynamically target and update items, even when they are duplicated across different categories.
- Update both client-side and server-side code to support the new behavior, ensuring consistency when toggling items between "completed" and "incomplete" states.
- The "mark incomplete" feature is now updated to work correctly with the `_id` targeting.

### Testing  
- Manually test the functionality in each grocery list category, confirming that the "mark complete" and "mark incomplete" actions dynamically apply to the correct item based on its `_id`.
- Test categories with multiple items and duplicates, ensuring that the functionality works for all cases.

### Future Work  
- Refactor logic for grocery list page’s delete and num counter functionality, incorporating ‘_id’ targeting
- Refactor logic for meal plan page’s delete and mark in/complete functionality, also incorporating ‘_id’ targeting

### Related Issues  
- Fixes issue-#7

### Commits in this PR  
- chore: delete old mark in/complete functions for individual sections of grocery list  
- bugfix: grocery list mark in/complete works dynamically for each category using _id. manually test for functionality in each category.  
- bugfix: update the mark in/complete functionality so it dynamically targets the grocery list item. manually test to work effectively for multiple items under produce section, including duplicates.  
- bugfix: mark incomplete now also works for grocery list with this targeted object id.  
- bugfix: use _id to target grocery list item. This is the first instance of it working. not thoroughly test yet.  
- add incomplete class to grocery list items. display mongodb id inside of grocery list li id attribute  
- create server-side logic for mark complete grocery list - all categories
