### PR TITLE
Fix Broken Meal Plan Page Note Functionality

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -151,29 +151,14 @@ function addNoteToItem() {
     console.log('Note button has been clicked')
 }
 
-// if (document.querySelector('#meal-plan-heading')) {
-//     notesSaveBtn.addEventListener('click', editNote)
-// }
-
 
 Array.from(notesSaveBtn).forEach( element => {
     // console.log('Array.from(showNoteBtn): ', showNoteBtn)
     element.addEventListener('click', editNote)
 })
-// notesSaveBtn.addEventListener('click', editNote)
-    
-
-// Array.from(notesSaveBtn).forEach( element => {
-//     console.log('Array.from(notesSaveBtn): ', notesSaveBtn)
-//     element.addEventListener('click', editNoteTestTestTest)
-
-//     // when you click the save button, send the text from the contenteditable div to the server. Update mealPlanStuff[i].note with that text. Then refresh the page.
-    
-// })
 
 
 async function editNote(){
-    const itemText = this.parentNode.childNodes[1].innerText
     const noteText = this.parentNode.childNodes[10].innerText
     const id = this.parentNode.id
     const checkmark = this.parentNode.childNodes[13]

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -178,8 +178,8 @@ async function editNote(){
     const id = this.parentNode.id
     const checkmark = this.parentNode.childNodes[13]
 
-    
-    // console.log(this.parentNode.childNodes)
+    console.log('id', id)
+    // console.log(this.parentNode.childNodes
 
     // id = id.charAt(0).toUpperCase() + id.slice(1)
     // console.log('editNote id: ', id)
@@ -187,11 +187,11 @@ async function editNote(){
     // console.log(noteText)
 
     try{
-        const response = await fetch(`edit-note-${id}`, {
+        const response = await fetch(`edit-note`, {
             method: 'put',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
-                'itemFromJS': itemText,
+                'idFromJS': id,
                 'noteFromJS': noteText
             })
           })

--- a/server.js
+++ b/server.js
@@ -98,8 +98,7 @@ MongoClient.connect(dbConnectionStr)
 
     
 
-    // Note Update! Start
-    // Monday Begin
+    // Note update
     app.put("/edit-note", (request, response) => {
       mealPlanCollection
         .updateOne(
@@ -116,123 +115,10 @@ MongoClient.connect(dbConnectionStr)
         })
         .catch((error) => console.error(error));
     });
-    // Monday End
 
-    // Tuesday Begin
-    app.put("/edit-note-tuesday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { tuesdaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan tuesday");
-          response.json("Updated note meal plan tuesday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Tuesday End
+  
 
-    // Wednesday Begin
-    app.put("/edit-note-wednesday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { wednesdaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan wednesday");
-          response.json("Updated note meal plan wednesday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Wednesday End
 
-    // Thursday Begin
-    app.put("/edit-note-thursday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { thursdaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan thursday");
-          response.json("Updated note meal plan thursday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Thursday End
-
-    // Friday Begin
-    app.put("/edit-note-friday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { fridaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan friday");
-          response.json("Updated note meal plan friday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Friday End
-
-    // Saturday Begin
-    app.put("/edit-note-saturday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { saturdaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan saturday");
-          response.json("Updated note meal plan saturday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Saturday End
-
-    // Sunday Begin
-    app.put("/edit-note-sunday", (request, response) => {
-      mealPlanCollection
-        .updateOne(
-          { sundaymeal: request.body.itemFromJS },
-          { $set: { note: request.body.noteFromJS } },
-          {
-            sort: { _id: -1 },
-            upsert: false,
-          }
-        )
-        .then((result) => {
-          console.log("Updated note meal plan sunday");
-          response.json("Updated note meal plan sunday");
-        })
-        .catch((error) => console.error(error));
-    });
-    // Sunday End
-
-    // Note Update! End
 
     // Delete! Start
     app.delete("/deleteItem", (request, response) => {

--- a/server.js
+++ b/server.js
@@ -100,10 +100,10 @@ MongoClient.connect(dbConnectionStr)
 
     // Note Update! Start
     // Monday Begin
-    app.put("/edit-note-monday", (request, response) => {
+    app.put("/edit-note", (request, response) => {
       mealPlanCollection
         .updateOne(
-          { mondaymeal: request.body.itemFromJS },
+          { _id: new ObjectId(request.body.idFromJS)},
           { $set: { note: request.body.noteFromJS } },
           {
             sort: { _id: -1 },
@@ -111,8 +111,8 @@ MongoClient.connect(dbConnectionStr)
           }
         )
         .then((result) => {
-          console.log("Updated note meal plan Monday");
-          response.json("Updated note meal plan Monday");
+          console.log("Updated note meal plan");
+          response.json("Updated note meal plan");
         })
         .catch((error) => console.error(error));
     });


### PR DESCRIPTION
### Overview
This pull request addresses the issue of broken functionality with the Meal Plan page note feature (#14). The notes section for meal plans was not properly saving or updating, preventing users from adding or editing notes effectively.

### Features Added
- Removes outdated meal plan note logic to clean up the codebase.
- Modifies the note editing logic to use the unique _id from the database for more reliable handling.
- Ensures the new note logic works correctly across all days in the meal plan.

### Implementation Details
- Refactors the meal plan note functionality by removing old logic that was causing issues with saving and displaying notes. The old logic could not properly handle duplicates, due to its buggy item targeting system
- Updates the note editing process to use the _id field from the database, ensuring that notes are correctly tied to their respective meal plan items

### Testing
- Manually tests the ability to add and edit notes for all days in the meal plan.
- Confirms that notes are saved correctly and persist across page reloads.

### Future Work
- Further refine the meal plan UI to improve user interaction with note inputs.
- Explore adding validation for note content (e.g., character limits or empty note checks).

### Related Issues
- Fixes issue-#14

### Commits in this PR
- chore: remove old meal plan note logic. clean up spacing for consistency.
- bugfix: modify meal plan note editing logic to utilize _id from database. test it for all days.
