### PR TITLE
Fix Grocery List item count button logic

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -255,10 +255,16 @@ Array.from(decrease).forEach(element => {
     element.addEventListener('click', subNumOfItem)
 })
 
+console.log('increase: ', Array.from(increase))
+console.log('decrease: ', Array.from(decrease))
+
 async function addNumOfItem(){
     const itemNameS = this.parentNode.querySelector('.item-name').innerText
     const numItemS = this.parentNode.querySelector('.num-of-item').innerText
-    console.log('numItemS:', numItemS);
+
+    console.log('itemNameS', itemNameS)
+    console.log('numItemS:', numItemS)
+
     try{
         const response = await fetch('addNum', {
             method: 'put',
@@ -270,7 +276,8 @@ async function addNumOfItem(){
           })
         const data = await response.json()
         console.log(data)
-        location.reload()
+
+        // location.reload()
 
     }catch(err){
         console.log(err)
@@ -280,7 +287,10 @@ async function addNumOfItem(){
 async function subNumOfItem(){
     const itemNameS = this.parentNode.querySelector('.item-name').innerText
     const numItemS = this.parentNode.querySelector('.num-of-item').innerText
-    console.log('numItemS:', numItemS);
+    
+    console.log('itemNameS', itemNameS)
+    console.log('numItemS:', numItemS)
+
     try{
         const response = await fetch('subNum', {
             method: 'put',
@@ -292,7 +302,8 @@ async function subNumOfItem(){
           })
         const data = await response.json()
         console.log(data)
-        location.reload()
+
+        // location.reload()
 
     }catch(err){
         console.log(err)

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -259,25 +259,28 @@ console.log('increase: ', Array.from(increase))
 console.log('decrease: ', Array.from(decrease))
 
 async function addNumOfItem(){
-    const itemNameS = this.parentNode.querySelector('.item-name').innerText
-    const numItemS = this.parentNode.querySelector('.num-of-item').innerText
+    // const itemName = this.parentNode.querySelector('.item-name').innerText
+    const numItem = this.parentNode.querySelector('.num-of-item').innerText
 
-    console.log('itemNameS', itemNameS)
-    console.log('numItemS:', numItemS)
+    const id = this.parentNode.id
+    // console.log('id ', id)
+
+    // console.log('itemNameS', itemNameS)
+    // console.log('numItemS:', numItemS)
 
     try{
         const response = await fetch('addNum', {
             method: 'put',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
-              'itemName': itemNameS,
-              'numItem': numItemS
+              'idFromJS': id,
+              'numItem': numItem
             })
           })
         const data = await response.json()
         console.log(data)
 
-        // location.reload()
+        location.reload()
 
     }catch(err){
         console.log(err)
@@ -285,25 +288,28 @@ async function addNumOfItem(){
 }
 
 async function subNumOfItem(){
-    const itemNameS = this.parentNode.querySelector('.item-name').innerText
-    const numItemS = this.parentNode.querySelector('.num-of-item').innerText
-    
-    console.log('itemNameS', itemNameS)
-    console.log('numItemS:', numItemS)
+    // const itemName = this.parentNode.querySelector('.item-name').innerText
+    const numItem = this.parentNode.querySelector('.num-of-item').innerText
+
+    const id = this.parentNode.id
+    // console.log('id ', id)
+
+    // console.log('itemNameS', itemNameS)
+    // console.log('numItemS:', numItemS)
 
     try{
         const response = await fetch('subNum', {
             method: 'put',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
-              'itemName': itemNameS,
-              'numItem': numItemS
+              'idFromJS': id,
+              'numItem': numItem
             })
           })
         const data = await response.json()
         console.log(data)
 
-        // location.reload()
+        location.reload()
 
     }catch(err){
         console.log(err)

--- a/server.js
+++ b/server.js
@@ -190,6 +190,11 @@ MongoClient.connect(dbConnectionStr)
 
 
 
+
+
+
+
+
     // ~~~~~~~~~
     // GROCERY LIST Start
     // ~~~~~~~~~
@@ -228,7 +233,7 @@ MongoClient.connect(dbConnectionStr)
       console.log("Received PUT request:", req.body);
       groceryListCollection
         .updateOne(
-          { itemName: req.body.itemName },
+          { itemNameProduce: req.body.itemName },
           { $set: { numItem: Number(req.body.numItem) + 1 } }
         )
         .then((result) => {
@@ -243,7 +248,7 @@ MongoClient.connect(dbConnectionStr)
       console.log("Received PUT request:", req.body);
       groceryListCollection
         .updateOne(
-          { itemName: req.body.itemName },
+          { itemNameProduce: req.body.itemName },
           { $set: { numItem: Number(req.body.numItem) - 1 } }
         )
         .then((result) => {

--- a/server.js
+++ b/server.js
@@ -233,7 +233,7 @@ MongoClient.connect(dbConnectionStr)
       console.log("Received PUT request:", req.body);
       groceryListCollection
         .updateOne(
-          { itemNameProduce: req.body.itemName },
+          { _id: new ObjectId(req.body.idFromJS) },
           { $set: { numItem: Number(req.body.numItem) + 1 } }
         )
         .then((result) => {
@@ -248,7 +248,7 @@ MongoClient.connect(dbConnectionStr)
       console.log("Received PUT request:", req.body);
       groceryListCollection
         .updateOne(
-          { itemNameProduce: req.body.itemName },
+          { _id: new ObjectId(req.body.idFromJS) },
           { $set: { numItem: Number(req.body.numItem) - 1 } }
         )
         .then((result) => {


### PR DESCRIPTION
### Overview
This pull request addresses the issue where the grocery list item count functionality is broken (#16). The problem involves incorrect behavior when incrementing and decrementing the quantity of grocery list items, especially when dealing with duplicate items.

### Features Added
- Refactors the grocery list item quantity increment and decrement functionality to target items by their unique `_id` from the database.

### Implementation Details
- The most recent commit refactors the logic to correctly increment and decrement item quantities by targeting the unique `_id` field, ensuring the expected behavior when adjusting quantities.
- The oldest commit revives older, less stable logic to at least provide partial functionality for adjusting quantities within the produce section, though it doesn't handle duplicates or work seamlessly across the entire list.

### Testing
- Manual testing confirms that the refactored logic works as expected, allowing for accurate quantity updates, including for duplicate items.
- The revived logic works under limited conditions (in the produce section), but does not handle duplicate items or all list sections properly.

### Future Work
- Update styling and of item inc/decrement buttons and possibly change the sudden appearance of the decrement button for a better UX

### Related Issues
- Fixes issue-#16

### Commits in this PR
- bugfix: refactored grocery list item quantity inc/decrease so it targets items with _id from database. Functionality works as expected per manual testing, including for duplicate items.
- bugfix: revived old logic so grocery list item quantity inc/decrease works in a janky fashion. It only works under the produce section and it does not work correctly with duplicates.
