### PR TITLE
Sign up page link should change to light purple on hover

### DIFF
--- a/views/grocery-list-demo.ejs
+++ b/views/grocery-list-demo.ejs
@@ -31,7 +31,7 @@
                     <p class="hidden sm:inline lg:block"><a href="/log-out" class="italic text-lg text-gray-400 hover:text-gray-500">Log out</a></p>
                   <% } else { %>
                     <a href="log-in" class="hidden sm:inline text-lg text-gray-800 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 focus:outline-none hover:text-gray-500">Log In</a>
-                    <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-gray-500">Sign Up</a>
+                    <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-indigo-500">Sign Up</a>
                   <% } %> 
                     <button data-collapse-toggle="mobile-menu-2" type="button" class="inline-flex items-center p-2 ml-1 text-lg text-gray-500 rounded-lg lg:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="mobile-menu-2" aria-expanded="false">
                         <span class="sr-only">Open main menu</span>
@@ -84,7 +84,7 @@
                           <a href="log-in" class="block py-2 pr-4 pl-3 text-lg leading-5 text-gray-700 lg:border-0 lg:p-0 hover:text-gray-500">Log In</a>
                         </li>
                         <li class="sm:hidden">
-                          <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-gray-500">Sign Up</a>
+                          <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-indigo-500">Sign Up</a>
                         </li>
                       </ul>
                     </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -31,7 +31,7 @@
                 <p class="hidden sm:inline lg:block"><a href="/log-out" class="italic text-lg text-gray-400 hover:text-gray-500">Log out</a></p>
               <% } else { %>
                 <a href="log-in" class="hidden sm:inline text-lg text-gray-800 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 focus:outline-none hover:text-gray-500">Log In</a>
-                <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-gray-500">Sign Up</a>
+                <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-indigo-500">Sign Up</a>
               <% } %> 
                 <button data-collapse-toggle="mobile-menu-2" type="button" class="inline-flex items-center p-2 ml-1 text-lg text-gray-500 rounded-lg lg:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="mobile-menu-2" aria-expanded="false">
                     <span class="sr-only">Open main menu</span>
@@ -84,7 +84,7 @@
                       <a href="log-in" class="block py-2 pr-4 pl-3 text-lg leading-5 text-gray-700 lg:border-0 lg:p-0 hover:text-gray-500">Log In</a>
                     </li>
                     <li class="sm:hidden">
-                      <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-gray-500">Sign Up</a>
+                      <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-indigo-500">Sign Up</a>
                     </li>
                   </ul>
                 </div>

--- a/views/meal-plan-demo.ejs
+++ b/views/meal-plan-demo.ejs
@@ -30,7 +30,7 @@
                 <p class="hidden sm:inline lg:block"><a href="/log-out" class="italic text-lg text-gray-400 hover:text-gray-500">Log out</a></p>
               <% } else { %>
                 <a href="log-in" class="hidden sm:inline text-lg text-gray-800 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 focus:outline-none hover:text-gray-500">Log In</a>
-                <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-gray-500">Sign Up</a>
+                <a href="sign-up" class="hidden sm:inline text-lg text-[#4f46e5] bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg px-4 lg:px-5 py-2 lg:py-2.5 mr-2 hover:text-indigo-500">Sign Up</a>
               <% } %> 
                 <button data-collapse-toggle="mobile-menu-2" type="button" class="inline-flex items-center p-2 ml-1 text-lg text-gray-500 rounded-lg lg:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200" aria-controls="mobile-menu-2" aria-expanded="false">
                     <span class="sr-only">Open main menu</span>
@@ -83,7 +83,7 @@
                       <a href="log-in" class="block py-2 pr-4 pl-3 text-lg leading-5 text-gray-700 lg:border-0 lg:p-0 hover:text-gray-500">Log In</a>
                     </li>
                     <li class="sm:hidden">
-                      <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-gray-500">Sign Up</a>
+                      <a href="sign-up" class="block py-2 pr-4 pl-3 text-lg leading-5 text-[#4f46e5] lg:border-0 lg:p-0 hover:text-indigo-500">Sign Up</a>
                     </li>
                   </ul>
                 </div>


### PR DESCRIPTION
This pull request adds updates the styling when the user hovers over the Sign Up link, so it becomes a lighter shade of its existing purple, rather than of grey.

Fixes issue-#38