### PR TITLE
Turn Trash Can Icons into Buttons & Update Note Edit Logic

### DIFF
--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -147,10 +147,10 @@ function addNoteToItem() {
     // document.querySelector('.item-note-form').style.display = 'block'
 
     // notes.classList.toggle('item-note-display-toggle')
-    this.parentNode.parentNode.childNodes[10].classList.toggle('item-note-display-toggle')
+    this.parentNode.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
     // notesSaveBtn.classList.toggle('button-display-toggle')
-    this.parentNode.parentNode.childNodes[12].classList.toggle('button-display-toggle')
-    console.log('Note button has been clicked')
+    this.parentNode.parentNode.childNodes[13].classList.toggle('button-display-toggle')
+    // console.log('Note button has been clicked')
 }
 
 
@@ -161,15 +161,15 @@ Array.from(notesSaveBtn).forEach( element => {
 
 
 async function editNote(){
-    const noteText = this.parentNode.childNodes[10].innerText
+    const noteText = this.parentNode.childNodes[11].innerText
     const id = this.parentNode.id
-    const checkmark = this.parentNode.childNodes[13]
+    const checkmark = this.parentNode.childNodes[14]
 
-    console.log('id', id)
+    // console.log('id', id)
     // console.log(this.parentNode.childNodes)
 
     // id = id.charAt(0).toUpperCase() + id.slice(1)
-    console.log('editNote id: ', id)
+    // console.log('editNote id: ', id)
     // console.log(itemText)
     // console.log(noteText)
 
@@ -183,7 +183,7 @@ async function editNote(){
             })
           })
         const data = await response.json()
-        console.log(data)
+        // console.log(data)
 
         checkmark.classList.add('checkmark-display')
         setTimeout( _ => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -40,6 +40,7 @@ Array.from(deleteBtn).forEach((element)=>{
 async function deleteItem(){
     // const itemText = this.parentNode.childNodes[1].innerText
     let id = this.parentNode.id
+    // console.log(this.parentNode)
 
     try{
         const response = await fetch('meal-plan/deleteMealPlanItem', {
@@ -383,7 +384,7 @@ async function deleteItemGroceryList(){
     // console.log(itemText)
 
     const id = this.parentNode.id
-    console.log(id)
+    // console.log(id)
 
     try{
         const response = await fetch('grocery-list/deleteItemGroceryList', {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -143,15 +143,16 @@ Array.from(showNoteBtn).forEach( element => {
 
 function addNoteToItem() {
     // console.log('notes: ', notes)
+    // console.log('this: ', this)
 
     // console.log('the node list: ', this.parentNode.parentNode.childNodes)
     // document.querySelector('.item-note-form').style.display = 'block'
 
     // notes.classList.toggle('item-note-display-toggle')
-    this.parentNode.parentNode.childNodes[10].classList.toggle('item-note-display-toggle')
+    this.parentNode.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
     // notesSaveBtn.classList.toggle('button-display-toggle')
-    this.parentNode.parentNode.childNodes[12].classList.toggle('button-display-toggle')
-    console.log('Note button has been clicked')
+    this.parentNode.parentNode.childNodes[13].classList.toggle('button-display-toggle')
+    // console.log('Note button has been clicked')
 }
 
 
@@ -162,9 +163,9 @@ Array.from(notesSaveBtn).forEach( element => {
 
 
 async function editNote(){
-    const noteText = this.parentNode.childNodes[10].innerText
+    const noteText = this.parentNode.childNodes[11].innerText
     const id = this.parentNode.id
-    const checkmark = this.parentNode.childNodes[13]
+    const checkmark = this.parentNode.childNodes[14]
 
     console.log('id', id)
     // console.log(this.parentNode.childNodes)

--- a/views/grocery-list-demo.ejs
+++ b/views/grocery-list-demo.ejs
@@ -163,7 +163,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -219,7 +220,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -275,7 +277,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -331,7 +334,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -387,7 +391,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -156,7 +156,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -213,7 +214,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -269,7 +271,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -325,7 +328,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>
@@ -381,7 +385,8 @@
                               
                             <% } %>
 
-                            <span class='fa fa-trash grocery-list-trash'></span><br />
+                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <br />
                           </li>
                         <% } %>
                       <% } %>

--- a/views/meal-plan-demo.ejs
+++ b/views/meal-plan-demo.ejs
@@ -155,7 +155,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -163,7 +164,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -183,7 +185,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -191,7 +194,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -211,7 +215,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -219,7 +224,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -239,7 +245,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -247,7 +254,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -266,7 +274,8 @@
                           <span class="item-name complete" ><%= mealPlanDemoStuff[i].mondaymeal %></span> &nbsp
                           <button><span class="far fa-edit"></span></button>
                           <button><span class="far fa-sticky-note"></span></button>
-                          <span class='fa fa-trash meal-plan-trash'></span><br />
+                          <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                           <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                           <button class="save-button button1" type="button">save</button>
 
@@ -274,7 +283,8 @@
                           <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].mondaymeal %></span> &nbsp
                           <button><span class="far fa-edit"></span></button>
                           <button><span class="far fa-sticky-note"></span></button>
-                          <span class='fa fa-trash meal-plan-trash'></span><br />
+                          <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                           <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                           <button class="save-button button1" type="button">save</button>
                         <% } %>
@@ -330,7 +340,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -338,7 +349,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -358,7 +370,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -366,7 +379,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -386,7 +400,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -394,7 +409,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -414,7 +430,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -422,7 +439,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -477,7 +495,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -485,7 +504,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -505,7 +525,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -513,7 +534,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -533,7 +555,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -541,7 +564,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -560,7 +584,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -568,7 +593,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -624,7 +650,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -632,7 +659,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -652,7 +680,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -660,7 +689,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -680,7 +710,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -688,7 +719,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -708,7 +740,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -716,7 +749,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -773,7 +807,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -781,7 +816,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -801,7 +837,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -809,7 +846,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -829,7 +867,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -837,7 +876,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -857,7 +897,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -865,7 +906,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -922,7 +964,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -930,7 +973,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -950,7 +994,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -958,7 +1003,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -978,7 +1024,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -986,7 +1033,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1006,7 +1054,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1014,7 +1063,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1071,7 +1121,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1079,7 +1130,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1099,7 +1151,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1107,7 +1160,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1127,7 +1181,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1135,7 +1190,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1155,7 +1211,8 @@
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1163,7 +1220,8 @@
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -154,7 +154,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -162,7 +163,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -182,7 +184,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -190,7 +193,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -210,7 +214,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -218,7 +223,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -238,7 +244,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -246,7 +253,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -329,7 +337,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -337,7 +346,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -357,7 +367,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -365,7 +376,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -385,7 +397,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -393,7 +406,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -413,7 +427,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -421,7 +436,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -476,7 +492,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -484,7 +501,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -504,7 +522,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -512,7 +531,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -532,7 +552,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -540,7 +561,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -559,7 +581,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -567,7 +590,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -623,7 +647,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -631,7 +656,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -651,7 +677,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -659,7 +686,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -679,7 +707,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -687,7 +716,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -707,7 +737,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -715,7 +746,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -772,7 +804,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -780,7 +813,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -800,7 +834,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -808,7 +843,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -828,7 +864,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -836,7 +873,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -856,7 +894,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -864,7 +903,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -921,7 +961,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -929,7 +970,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -949,7 +991,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -957,7 +1000,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -977,7 +1021,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -985,7 +1030,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1005,7 +1051,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1013,7 +1060,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1070,7 +1118,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1078,7 +1127,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1098,7 +1148,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1106,7 +1157,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1126,7 +1178,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1134,7 +1187,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
@@ -1154,7 +1208,8 @@
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
@@ -1162,7 +1217,8 @@
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
                             <button><span class="far fa-sticky-note"></span></button>
-                            <span class='fa fa-trash meal-plan-trash'></span><br />
+                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>


### PR DESCRIPTION
### Overview

This pull request updates the meal plan, grocery list, and their respective demo pages by converting trash can icons into interactive buttons. Additionally, it refines the note edit and save logic to accommodate these changes.

### Features Added

- Updates all instances of trash can icons, turning them into buttons for better accessibility and interaction.
- Adjusts note edit and save logic to reflect changes in the NodeList structure after replacing trash can icons with buttons.

### Implementation Details

- Replaces trash can \<span> with `<button>` elements, ensuring they remain functional while improving accessibility.
- Updates JavaScript logic that interacts with these elements to properly handle the new button structure.
- Ensures consistency across both the grocery list and meal plan demo pages by making uniform updates.

### Testing

- Manually tested note editing and saving functionality to confirm it works as expected with the updated button structure.
- Verified that the trash can buttons remain fully functional for deleting items in both demos.

### Future Work

- Continue large styling revamp.
- Evaluate additional accessibility improvements across the demo pages.

### Related Issues

- Closes issue-#45

### Commits in this PR

- `8a65056` fix: note edit and save logic in demo slightly updated due to change in NodeList from me changing trash cans to buttons.
- `a1ec020` fix: note edit and save logic slightly updated due to change in NodeList from me changing trash cans to buttons.
- `21eb120` fix: change meal plan demo page instances of trash can icon into a button.
- `35e9e68` fix: change grocery list demo page instances of trash can icon into a button.
- `2564501` fix: change grocery list page instances of trash can icon into a button.
- `ec3dfe7` fix: change meal plan page instances of trash can icon into a button.
