### PR TITLE
Add Visual Separation Between Forms and Headings

### DIFF
--- a/views/grocery-list-demo.ejs
+++ b/views/grocery-list-demo.ejs
@@ -129,7 +129,7 @@
                     Fruits / Vegetables
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST">
+                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="produce">
@@ -186,7 +186,7 @@
                     Proteins
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST">
+                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="proteins">
@@ -243,7 +243,7 @@
                     Grains / Legumes / Nuts / Seeds
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST">
+                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="pantry">
@@ -300,7 +300,7 @@
                     Fats / Spices / Condiments
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST">
+                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="condiments">
@@ -357,7 +357,7 @@
                     Other
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST">
+                    <form action="/grocery-list-demo/createGroceryListDemoItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="other">

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -122,7 +122,7 @@
                     Fruits / Vegetables
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list/createGroceryListItem" method="POST">
+                    <form action="/grocery-list/createGroceryListItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="produce">
@@ -180,7 +180,7 @@
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
 
-                    <form action="/grocery-list/createGroceryListItem" method="POST">
+                    <form action="/grocery-list/createGroceryListItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="proteins">
@@ -237,7 +237,7 @@
                     Grains / Legumes / Nuts / Seeds
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list/createGroceryListItem" method="POST">
+                    <form action="/grocery-list/createGroceryListItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="pantry">
@@ -294,7 +294,7 @@
                     Fats / Spices / Condiments
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list/createGroceryListItem" method="POST">
+                    <form action="/grocery-list/createGroceryListItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="condiments">
@@ -351,7 +351,7 @@
                     Other
                   </dt>
                   <dd class="mt-2 text-base leading-7 text-gray-600">
-                    <form action="/grocery-list/createGroceryListItem" method="POST">
+                    <form action="/grocery-list/createGroceryListItem" method="POST" class="mb-2">
                       <div class="flex justify-between w-4/5 sm:w-3/4 lg:w-4/5">
                         <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" type="text" placeholder="Add Item" name="item">
                         <input type="hidden" name="category" value="other">

--- a/views/meal-plan-demo.ejs
+++ b/views/meal-plan-demo.ejs
@@ -128,7 +128,7 @@
                 Monday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Monday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -309,7 +309,7 @@
                 Tuesday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Tuesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -464,7 +464,7 @@
                 Wednesday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Wednesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -619,7 +619,7 @@
                 Thursday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Thursday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -776,7 +776,7 @@
                 Friday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Friday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -933,7 +933,7 @@
                 Saturday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Saturday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -1090,7 +1090,7 @@
                 Sunday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Sunday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -123,7 +123,7 @@
                 Monday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Monday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -306,7 +306,7 @@
                 Tuesday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Tuesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -461,7 +461,7 @@
                 Wednesday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Wednesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -616,7 +616,7 @@
                 Thursday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Thursday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -773,7 +773,7 @@
                 Friday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Friday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -930,7 +930,7 @@
                 Saturday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Saturday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
@@ -1087,7 +1087,7 @@
                 Sunday
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
-                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap">
+                <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
                   <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Sunday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->


### PR DESCRIPTION
### Overview

This pull request improves the visual layout of meal plan and grocery list pages (both demo and auth'd versions) by adding bottom margins to forms, creating clearer separation between form elements and headings for better readability.

### Features Added

- Adds bottom margin to demo forms to enhance spacing and improve UI clarity.
- Ensures consistency across all forms by applying uniform margin updates.

### Implementation Details

- Updates Tailwind styles to introduce bottom margins for forms.
- Applies changes across multiple form elements to maintain design consistency.

### Testing

- Manually verified that forms now have improved spacing and no longer appear too close to headings.
- Checked that changes are consistent across different demo pages.

### Future Work

- Review additional spacing adjustments for other UI elements that may benefit from improved layout separation.

### Related Issues

- Closes issue-18

### Commits in this PR

- `7738aa3` feat: add bottom margin to demo forms.
- `2a28b49` feat: add bottom margin to forms.
- `313ead5` feat: add bottom margin to demo forms.
- `6685b67` feat: add bottom margin to forms.