### PR TITLE
Feature/issue 50/issue 46/add hover styling to crud buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,6 +2,9 @@
     color: gray;
     text-decoration: line-through;
 }
+.item-name {
+    cursor: pointer;
+}
 
 .hidden {
     display: none;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5,6 +5,12 @@
 .item-name {
     cursor: pointer;
 }
+.item-name.complete:hover {
+    color:#327d3e;
+}
+.item-name.incomplete:hover {
+    color: #7d3232;
+}
 
 .hidden {
     display: none;

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -219,8 +219,8 @@ async function editNote(){
 // Grocery List Start
 // ~~~~~~~~~
 
-const increase = document.querySelectorAll('#add-num-button')
-const decrease = document.querySelectorAll('#sub-num-button')
+const increase = document.querySelectorAll('.add-num-button')
+const decrease = document.querySelectorAll('.sub-num-button')
 const incompleteGroceryList = document.querySelectorAll('#grocery-list .item span.item-name.incomplete')
 const completeGroceryList = document.querySelectorAll('#grocery-list .item span.item-name.complete')
 

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -147,9 +147,9 @@ function addNoteToItem() {
     // document.querySelector('.item-note-form').style.display = 'block'
 
     // notes.classList.toggle('item-note-display-toggle')
-    this.parentNode.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
+    this.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
     // notesSaveBtn.classList.toggle('button-display-toggle')
-    this.parentNode.parentNode.childNodes[13].classList.toggle('button-display-toggle')
+    this.parentNode.childNodes[13].classList.toggle('button-display-toggle')
     // console.log('Note button has been clicked')
 }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -146,12 +146,13 @@ function addNoteToItem() {
     // console.log('this: ', this)
 
     // console.log('the node list: ', this.parentNode.parentNode.childNodes)
+    // console.log('the node list: ', this.parentNode.childNodes)
     // document.querySelector('.item-note-form').style.display = 'block'
 
     // notes.classList.toggle('item-note-display-toggle')
-    this.parentNode.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
+    this.parentNode.childNodes[11].classList.toggle('item-note-display-toggle')
     // notesSaveBtn.classList.toggle('button-display-toggle')
-    this.parentNode.parentNode.childNodes[13].classList.toggle('button-display-toggle')
+    this.parentNode.childNodes[13].classList.toggle('button-display-toggle')
     // console.log('Note button has been clicked')
 }
 
@@ -167,11 +168,11 @@ async function editNote(){
     const id = this.parentNode.id
     const checkmark = this.parentNode.childNodes[14]
 
-    console.log('id', id)
+    // console.log('id', id)
     // console.log(this.parentNode.childNodes)
 
     // id = id.charAt(0).toUpperCase() + id.slice(1)
-    console.log('editNote id: ', id)
+    // console.log('editNote id: ', id)
     // console.log(itemText)
     // console.log(noteText)
 
@@ -185,7 +186,7 @@ async function editNote(){
             })
           })
         const data = await response.json()
-        console.log(data)
+        // console.log(data)
 
         checkmark.classList.add('checkmark-display')
         setTimeout( _ => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -222,8 +222,8 @@ async function editNote(){
 // Grocery List Start
 // ~~~~~~~~~
 
-const increase = document.querySelectorAll('#add-num-button')
-const decrease = document.querySelectorAll('#sub-num-button')
+const increase = document.querySelectorAll('.add-num-button')
+const decrease = document.querySelectorAll('.sub-num-button')
 const incompleteGroceryList = document.querySelectorAll('#grocery-list .item span.item-name.incomplete')
 const completeGroceryList = document.querySelectorAll('#grocery-list .item span.item-name.complete')
 

--- a/views/grocery-list-demo.ejs
+++ b/views/grocery-list-demo.ejs
@@ -152,18 +152,17 @@
                             <% } %>
 
                             <% if(groceryListDemoItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -209,18 +208,17 @@
                             <% } %>
 
                             <% if(groceryListDemoItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -266,18 +264,18 @@
                             <% } %>
 
                             <% if(groceryListDemoItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
+                            <br />
                             <br />
                           </li>
                         <% } %>
@@ -323,18 +321,17 @@
                             <% } %>
 
                             <% if(groceryListDemoItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -380,18 +377,17 @@
                             <% } %>
 
                             <% if(groceryListDemoItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListDemoItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -153,7 +153,6 @@
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
                               <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
-                              
                             <% } %>
 
                             <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
@@ -203,18 +202,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -260,18 +258,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -317,18 +314,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>
@@ -374,18 +370,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
-                              
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -145,14 +145,14 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
                             <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
@@ -202,14 +202,14 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
                             <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
@@ -258,14 +258,14 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
                             <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
@@ -314,17 +314,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
+                            <button class='fa fa-trash grocery-list-trash'></button>
                             <br />
                           </li>
                         <% } %>
@@ -370,17 +370,17 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
+                              <button class="sub-num-button text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
+                              <button class="add-num-button text-gray-600 hover:text-gray-500 font-bold">+</button>
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
+                            <button class='fa fa-trash grocery-list-trash'></button>
                             <br />
                           </li>
                         <% } %>

--- a/views/grocery-list.ejs
+++ b/views/grocery-list.ejs
@@ -145,18 +145,18 @@
                             <% } %>
 
                             <% if(groceryListItems[i].numItem >= 2) { %>
-                              <button id="sub-num-button">-</button>
+                              <button id="sub-num-button" class="text-gray-600 hover:text-gray-500 font-bold">-</button>
                               <span class="num-of-item"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
 
                             <% } else { %>
                               <span class="num-of-item hidden"><%= groceryListItems[i].numItem %></span>
-                              <button id="add-num-button">+</button>
+                              <button id="add-num-button" class="text-gray-600 hover:text-gray-500 font-bold">+</button>
                               
                             <% } %>
 
-                            <button class='fa fa-trash grocery-list-trash'></button>
+                            <button class='fa fa-trash grocery-list-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                           </li>
                         <% } %>

--- a/views/meal-plan-demo.ejs
+++ b/views/meal-plan-demo.ejs
@@ -154,20 +154,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -184,20 +184,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -214,20 +214,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -244,20 +244,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -339,20 +339,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -369,20 +369,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -399,20 +399,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -429,20 +429,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -494,20 +494,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -524,20 +524,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -554,20 +554,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -583,20 +583,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -649,20 +649,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -679,20 +679,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -709,20 +709,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -739,20 +739,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -806,20 +806,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -836,20 +836,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -866,20 +866,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -896,20 +896,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -963,20 +963,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -993,20 +993,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1023,20 +1023,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1053,20 +1053,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1120,20 +1120,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1150,20 +1150,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1180,20 +1180,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1210,20 +1210,20 @@
                           <% if(mealPlanDemoStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanDemoStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanDemoStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -157,7 +157,7 @@
                             <button class='fa fa-trash meal-plan-trash'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 rounded-lg p-1 px-2 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
@@ -166,7 +166,7 @@
                             <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1 hover:bg-[#40BE85]" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -162,11 +162,11 @@
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 hover:bg-[#40BE85]" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1117,7 +1117,7 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
+                            <button><span class="fa fa-sticky-note"></span></button>
                             <button class='fa fa-trash meal-plan-trash'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -153,11 +153,11 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1 rounded-lg p-1 px-2 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
@@ -183,20 +183,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -213,20 +213,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -243,20 +243,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -336,20 +336,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -366,20 +366,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -396,20 +396,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -426,20 +426,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -491,20 +491,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -521,20 +521,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -551,20 +551,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -580,20 +580,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -646,20 +646,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -676,20 +676,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -706,20 +706,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -736,20 +736,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -803,20 +803,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -833,20 +833,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -863,20 +863,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -893,20 +893,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -960,20 +960,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -990,20 +990,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1020,20 +1020,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1050,20 +1050,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1126,11 +1126,11 @@
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1147,20 +1147,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1177,20 +1177,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>
@@ -1207,20 +1207,20 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
 
                           <% }else { %>
                             <span class="item-name incomplete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="far fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
-                            <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
+                            <button class="save-button button1 p-1 px-2 rounded-lg text-sm font-semibold text-white leading-7 hover:bg-[#40BE85]" type="button">Save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>
                           <% } %>
                         </li>
                       <% } %>


### PR DESCRIPTION
### Overview

This pull request enhances the grocery list, meal plan, and both demo pages by updating hover styling for CRUD buttons, improving user experience and visual feedback. Additionally, it refines button targeting logic for better consistency and functionality.

### Features Added

- Updates hover styling for add, subtract, and trash can buttons on the grocery list and grocery list demo pages, as well as note add, note save, and trash can buttons on meal plan and demo pages.
- Adds green and red hover styling to items on all 4 pages to indicate that the user can mark them complete or incomplete.

### Implementation Details

- Modifies button styles to improve visual feedback when users interact with CRUD buttons.
- Changes the add and subtract item logic to target buttons by class instead of incorrect ID targeting.
- Ensures consistent styling and hover effects across grocery list and meal plan pages and their respective demos.

### Testing

- Manually verified that all CRUD buttons display appropriate hover styling.
- Checked that meal plan items correctly change color when hovered over to indicate user mark in/complete functionality
- Confirmed that button functionality remains intact after adjusting targeting logic.

### Future Work

- Make the home page taller issue-#49

### Related Issues

- Closes issue-#46

### Commits in this PR

- `dc3544f` feat: update all add, subtract, and trash can buttons hover styling on grocery list demo.
- `409246b` fix: change add and subtract num item logic to target buttons by class rather than id which was incorrect.
- `b6aa982` feat: update all add, subtract, and trash can buttons hover styling on grocery list.
- `3f5dc5f` feat: update add, subtract, and trash can button hover styling on grocery list.
- `6059993` feat: add green and red hover styling to meal plan items to indicate marking them in/complete.
- `80e2d19` feat: update CRUD button styling across entire meal plan demo page, including changing the cursor when item spans are hovered over.
- `262c51b` feat: update CRUD button styling across entire meal plan page, including changing the cursor when item spans are hovered over.
- `d852464` feat: update note save button styling.
- `f16fc57` feat: add lighter color style to note add, trash can, and note save buttons for Monday breakfast. fix: remove span inside note button and update note add and edit element targeting logic.