### PR TITLE
Fix Cursor Positioning and Styling for Forms and Contenteditable Divs. Also CRUD Button Styling Hotfix

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -21,7 +21,8 @@
 .item-note {
     display: none;
     font-style: italic;
-    text-indent: 10px;
+    padding-left: 10px;
+    /* text-indent: 10px; */
     /* margin-bottom: 0.5rem; */
 }
 /* placeholder code for item note */
@@ -60,14 +61,6 @@
 
 .item-note-display-toggle {
     display: block;
-}
-
-
-.item-note {
-    display: none;
-    font-style: italic;
-    text-indent: 10px;
-    /* margin-bottom: 0.5rem; */
 }
 
 .save-button {

--- a/views/meal-plan-demo.ejs
+++ b/views/meal-plan-demo.ejs
@@ -133,7 +133,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Monday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Monday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <div class="flex justify-between w-4/5 sm:w-3/4">
                     <select class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7" name="mealtime" required>
@@ -314,7 +314,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Tuesday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Tuesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -469,7 +469,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Wednesday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Wednesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -624,7 +624,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Thursday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Thursday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -781,7 +781,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Friday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Friday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -938,7 +938,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Saturday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Saturday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -1095,7 +1095,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan-demo/createMealPlanDemoItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Sunday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Sunday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -128,7 +128,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Monday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Monday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -311,7 +311,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Tuesday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Tuesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -466,7 +466,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Wednesday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Wednesday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -621,7 +621,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Thursday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Thursday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -778,7 +778,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Friday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Friday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -935,7 +935,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Saturday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Saturday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">
@@ -1092,7 +1092,7 @@
               </dt>
               <dd class="mt-2 text-base leading-7 text-gray-600">
                 <form action="/meal-plan/createMealPlanItem" method="POST" class="flex flex-wrap mb-2">
-                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder=" Sunday meal" name="item" required />
+                  <input class="bg-gray-200 my-1 rounded-lg border-none p-1 pl-2 leading-7 w-4/5 sm:w-3/4" autocomplete="on" type="text" placeholder="Sunday meal" name="item" required />
                   <div class="basis-full h-0"></div>
                   <!-- <input class="bg-gray-200 my-1" autocomplete="on" list="mondaymealtimeslist" placeholder="which meal time?" name="mondaymealtime" required /> -->
                   <div class="flex justify-between w-4/5 sm:w-3/4">

--- a/views/meal-plan.ejs
+++ b/views/meal-plan.ejs
@@ -1121,8 +1121,8 @@
                           <% if(mealPlanStuff[i].complete === true) { %>
                             <span class="item-name complete" ><%= mealPlanStuff[i].item %></span> &nbsp
                             <!-- <button><span class="far fa-edit"></span></button> -->
-                            <button><span class="fa fa-sticky-note"></span></button>
-                            <button class='fa fa-trash meal-plan-trash'></button>
+                            <button class="far fa-sticky-note text-gray-600 hover:text-[#848A98]"></button>
+                            <button class='fa fa-trash meal-plan-trash text-gray-600 hover:text-gray-500'></button>
                             <br />
                             <div class="item-note" contenteditable="true" placeholder="e.g. Add extra cinnamon!"><%= mealPlanStuff[i].note %></div>
                             <button class="save-button button1" type="button">save</button><svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>


### PR DESCRIPTION
### Overview

This pull request addresses cursor positioning issues in form inputs and contenteditable divs, ensuring proper alignment of caret and placeholder text. Additionally, it fixes missing Tailwind classes on certain buttons.

### Features Added

- Removes unnecessary spaces at the beginning of placeholder text for meal plan demo item inputs.
- Adjusts styling of contenteditable divs to better align caret and placeholder text.
- Fixes missing Tailwind classes on Sunday breakfast note add and delete buttons on the meal plan page.

### Implementation Details

- Modifies form input fields to ensure placeholders display correctly without leading spaces.
- Updates padding and removes indentation on contenteditable divs (the notes on meal plan items) to improve caret positioning and readability.
- Applies necessary Tailwind classes to affected buttons to maintain consistency.

### Testing

- Manually verified that placeholder text no longer includes leading spaces.
- Confirmed that caret positioning is properly aligned in contenteditable divs.
- Checked that all buttons now have the correct Tailwind classes applied.

### Future Work

- That should be about it for styling issues

### Related Issues

- Closes issue-#4

### Commits in this PR

- `bb28d41` fix: Sunday breakfast note add and delete buttons were missing Tailwind classes.
- `3565804` fix: remove space at beginning of placeholder text for meal plan demo item input.
- `d1d0fc4` fix: remove space at beginning of placeholder text for meal plan item input.
- `9796a4e` fix: adjust styling of contenteditable divs to better align caret and placeholder text.